### PR TITLE
Fixed problem for pages with dinamic height

### DIFF
--- a/docs/jquery-inertiaScroll.js
+++ b/docs/jquery-inertiaScroll.js
@@ -109,6 +109,7 @@ Version:1.1.1
         }
       },
       loop:function(){
+        $body.height($parent.height());
         this.smoothScroll();
         window.requestAnimationFrame(this.loop.bind(this));
       }
@@ -118,7 +119,6 @@ Version:1.1.1
     // Done
     //////////////////////////////////////////////////
     $(function(){
-      $body.height($parent.height());
       var boxes = new Boxes();
       boxes.init();
     });


### PR DESCRIPTION
If page has dinamic height(example page has feed with infinite scroll ) we had problem with scroll because we get container height when we load page. 
It fix update height when we change it, because we watch container height in function "loop" 